### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", 'r') as readme:
 
 setup(
     name='vivarium-convenience',
-    version='0.0.2',
+    version='0.0.3',
     packages=[
         'vivarium_convenience',
         'vivarium_convenience.processes',

--- a/vivarium_convenience/processes/convenience_kinetics.py
+++ b/vivarium_convenience/processes/convenience_kinetics.py
@@ -288,18 +288,22 @@ class ConvenienceKinetics(Process):
                     # separate the state_id and port_id
                     if port_id in port_state_id:
                         state_id = port_state_id[1]
-                        state_flux = coeff * flux * timestep
+                        state_flux = (
+                            coeff * flux * timestep * units.millimolar)
 
                         if port_id == 'external':
                             # convert exchange fluxes to counts with mmol_to_counts
-                            delta = int((state_flux * mmol_to_counts).magnitude)
+                            delta = (state_flux * mmol_to_counts).to(
+                                units.count).magnitude
                             existing_delta = update['exchanges'].get(
-                                state_id, {}).get('_value', 0)
+                                state_id, 0)
                             update['exchanges'][state_id] = existing_delta + delta
+                        elif port_id == 'exchanges':
+                            continue
                         else:
                             update[port_id][state_id] = (
                                 update[port_id].get(state_id, 0)
-                                + state_flux
+                                + state_flux.magnitude
                             )
 
         # note: external and internal ports update change in mmol.

--- a/vivarium_convenience/processes/convenience_kinetics.py
+++ b/vivarium_convenience/processes/convenience_kinetics.py
@@ -136,6 +136,11 @@ class ConvenienceKinetics(Process):
                      'internal': ['A', 'B', 'C', 'E'],
                  }
 
+             * **flux_unit** (:py:class:`str`): Unit for molecular
+               fluxes. This unit should match the units in which all
+               reactant, enzyme, and product concentrations are
+               stored.
+
      The ports of the process are the ports configured by the
      user, with the following modifications:
 
@@ -214,6 +219,7 @@ class ConvenienceKinetics(Process):
             'exchanges',
             'global'
         ],
+        'flux_unit': 'mM',
         }
 
     def __init__(self, parameters=None):
@@ -289,7 +295,8 @@ class ConvenienceKinetics(Process):
                     if port_id in port_state_id:
                         state_id = port_state_id[1]
                         state_flux = (
-                            coeff * flux * timestep * units.millimolar)
+                            coeff * flux * timestep *
+                            units(self.parameters['flux_unit']))
 
                         if port_id == 'external':
                             # convert exchange fluxes to counts with mmol_to_counts


### PR DESCRIPTION
Includes the following fixes for the convenience kinetics process:

* Perform unit conversions so that even if mmol_to_counts is in another unit (e.g. fL/mmol), the calculations will still be correct.
* Allow fractional exchange to make simulations more accurate.
* Fix how we accumulate exchange when we have multiple reactions that perform exchange.